### PR TITLE
Change RSS URL

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,7 +13,7 @@ export default async function Blog() {
       <span className={styles.inline}>
         <h3>Blog</h3>
         <p className={`caption ${styles.rssLink}`}>
-          <Link href="/rss">RSS</Link>
+          <Link href="/rss.xml">RSS</Link>
         </p>
       </span>
 

--- a/generation/rss.tsx
+++ b/generation/rss.tsx
@@ -65,5 +65,5 @@ export default async function generateRssFeed(postsData) {
     });
   });
 
-  fs.writeFileSync('./public/rss', feed.rss2());
+  fs.writeFileSync('./public/rss.xml', feed.rss2());
 }


### PR DESCRIPTION


> #### What changed
 - Changed the link in the `app/blog/page.tsx` file from `/rss` to `/rss.xml`
 - Changed the file written to in the `generation/rss.tsx` file from `./public/rss` to `./public/rss.xml`
 
> #### Impact
 The RSS feed can now be accessed with the `/rss.xml` URL.
This supports more RSS readers’ direct open URL schemes

> #### Testing
The diff can be tested by navigating to the `/rss.xml` URL in a browser and verifying that the RSS feed is returned.